### PR TITLE
fixed issue #13

### DIFF
--- a/src/oktavia.jsx
+++ b/src/oktavia.jsx
@@ -179,7 +179,7 @@ class Oktavia
             {
                 var compressedCodeWord = this._convertToCompressionCode(originalWord);
                 var stemmedList = this._stemmingResult[registerWord];
-                if (!stemmedList)
+                if (!this._stemmingResult.hasOwnProperty(registerWord))
                 {
                     stemmedList = [compressedCodeWord];
                     this._stemmingResult[registerWord] = stemmedList;


### PR DESCRIPTION
The inherited properties like 'constructor' can be ignored by using obj.hasOwnProperty().
