### PR TITLE
remove definitions of unused variables

### DIFF
--- a/src/binary-util.jsx
+++ b/src/binary-util.jsx
@@ -529,7 +529,6 @@ class LoadedNumberListResult
     function constructor(data : string, offset : int)
     {
         var resultLength = Binary.load32bitNumber(data, offset);
-        var originalOffset = offset;
         offset += 2;
         var result = [] : number[];
         while (result.length < resultLength)

--- a/src/fm-index.jsx
+++ b/src/fm-index.jsx
@@ -241,7 +241,6 @@ class FMIndex
 
     function search (keyword : string) : int[]
     {
-        var result_map = {} : Map.<int>;
         var result = [] : int[];
         var position = [] : int[];
         var rows = this.getRows(keyword, position);

--- a/src/sax.jsx
+++ b/src/sax.jsx
@@ -841,8 +841,7 @@ class SAXParser
     function newTag () : void
     {
         if (!this.strict) this.tagName = this.tagName.toLowerCase();
-        var parent = this.tags[this.tags.length - 1] || this;
-        var tag = this.tag = new Tag(this.tagName);
+        this.tag = new Tag(this.tagName);
         this.attribList.length = 0;
     }
 
@@ -947,11 +946,10 @@ class SAXParser
         var s = this.tags.length;
         while (s --> t)
         {
-            var tag = this.tag = this.tags.pop();
+            this.tag = this.tags.pop();
             this.tagName = this.tag.name;
             this.closetext_if_exist();
             this.handler.onclosetag(this.tagName);
-            var parent = this.tags[this.tags.length - 1];
             if (this.tagName == 'pre')
             {
                 this.preTags--;

--- a/src/wavelet-matrix.jsx
+++ b/src/wavelet-matrix.jsx
@@ -279,14 +279,13 @@ class WaveletMatrix
         this.clear();
         this._bitsize = Binary.load16bitNumber(data, offset++);
         this._size = Binary.load32bitNumber(data, offset);
-        offset += 2; 
+        offset += 2;
         for (var i = 0; i < this.bitsize(); i++)
         {
             var bit_vector = new BitVector();
             offset = bit_vector.load(data, offset);
             this._bv.push(bit_vector);
         }
-        var sep = 0;
         for (var i = 0; i < this.bitsize(); i++, offset += 2)
         {
             this._seps.push(Binary.load32bitNumber(data, offset));

--- a/test/test-search-result.jsx
+++ b/test/test-search-result.jsx
@@ -143,6 +143,9 @@ class _Test extends TestCase
         var section1 = singleresult.getSearchUnit(0);
         var section2 = singleresult.getSearchUnit(1);
         var section3 = singleresult.getSearchUnit(2);
+        this.expect(section1.id).toBe(0);
+        this.expect(section2.id).toBe(1);
+        this.expect(section3.id).toBe(2);
 
         summary.add(singleresult);
         summary.mergeResult();


### PR DESCRIPTION
Version 0.9.62 of JSX compiler introduces "unused" warnings to detect unused variables, and thus there are some unused variables found in this project.

This pull-req removes unused variables although I'm not sure it's correct. Thanks.
