### PR TITLE
Do not work filter in HTMLParser.

### DIFF
--- a/src/htmlparser.jsx
+++ b/src/htmlparser.jsx
@@ -147,6 +147,7 @@ class _HTMLHandler extends SAXHandler
                 }
                 break;
             }
+            this.stack.pop();
             if (this.stack.length == 0)
             {
                 this.startParse = false;


### PR DESCRIPTION
I made search index of this html file.

``` html
<!DOCTYPE html>
<html>
  <head></head>
  <body>
    <div class="body">
      <pre>あいうえお</pre>
    </div>
    <div>かきくけこ</div>
  </body>
</html>
```

``` sh
./bin/oktavia-mkindex-cli -i ../hoge/ -r ../hoge/ -m html -u file -f .body -c 5 -t web
```

I had specified the filter `-f .body`. But it hits when I search for 'かき'.
