### PR TITLE
Support jQuery 3.x (Sphinx >= 1.5)

### DIFF
--- a/bin/web/oktavia-jquery-ui.js
+++ b/bin/web/oktavia-jquery-ui.js
@@ -401,7 +401,7 @@
             case 191: // / : focus form
                 eraseResultWindow();
                 var form = $('form.oktavia_form:first input.search');
-                if ($(':focus', form).size() === 0) {
+                if ($(':focus', form).length === 0) {
                     form.focus();
                 }
                 break;
@@ -411,7 +411,7 @@
             case 76: // l : next page
             case 13: // enter : select
                 var result = $('.oktavia_searchresult_box:visible:first');
-                if (result.size() === 1)
+                if (result.length === 1)
                 {
                     switch (event.keyCode)
                     {
@@ -454,7 +454,7 @@
 
 jQuery(document).ready(function () {
     var form = jQuery('#oktavia_search_form');
-    if (form.size() > 0)
+    if (form.length > 0)
     {
         form.oktaviaSearch();
     }

--- a/templates/jsdoc3/static/scripts/oktavia-jquery-ui.js
+++ b/templates/jsdoc3/static/scripts/oktavia-jquery-ui.js
@@ -457,7 +457,7 @@
             case 191: // / : focus form
                 eraseResultWindow();
                 var form = $('form.oktavia_form:first input.search');
-                if ($(':focus', form).size() === 0)
+                if ($(':focus', form).length === 0)
                 {
                     form.focus();
                 }
@@ -468,7 +468,7 @@
             case 76: // l : next page
             case 13: // enter : select
                 var result = $('.oktavia_searchresult_box:visible:first');
-                if (result.size() === 1)
+                if (result.length === 1)
                 {
                     switch (event.keyCode)
                     {
@@ -514,7 +514,7 @@
 
 jQuery(document).ready(function () {
     var form = jQuery('#oktavia_search_form');
-    if (form.size() > 0)
+    if (form.length > 0)
     {
         form.oktaviaSearch();
     }

--- a/templates/sphinx/_static/oktavia-jquery-ui.js
+++ b/templates/sphinx/_static/oktavia-jquery-ui.js
@@ -457,7 +457,7 @@
             case 191: // / : focus form
                 eraseResultWindow();
                 var form = $('form.oktavia_form:first input.search');
-                if ($(':focus', form).size() === 0)
+                if ($(':focus', form).length === 0)
                 {
                     form.focus();
                 }
@@ -468,7 +468,7 @@
             case 76: // l : next page
             case 13: // enter : select
                 var result = $('.oktavia_searchresult_box:visible:first');
-                if (result.size() === 1)
+                if (result.length === 1)
                 {
                     switch (event.keyCode)
                     {
@@ -514,7 +514,7 @@
 
 jQuery(document).ready(function () {
     var form = jQuery('#oktavia_search_form');
-    if (form.size() > 0)
+    if (form.length > 0)
     {
         form.oktaviaSearch();
     }

--- a/templates/tinkerer/_static/oktavia-jquery-ui.js
+++ b/templates/tinkerer/_static/oktavia-jquery-ui.js
@@ -457,7 +457,7 @@
             case 191: // / : focus form
                 eraseResultWindow();
                 var form = $('form.oktavia_form:first input.search');
-                if ($(':focus', form).size() === 0)
+                if ($(':focus', form).length === 0)
                 {
                     form.focus();
                 }
@@ -468,7 +468,7 @@
             case 76: // l : next page
             case 13: // enter : select
                 var result = $('.oktavia_searchresult_box:visible:first');
-                if (result.size() === 1)
+                if (result.length === 1)
                 {
                     switch (event.keyCode)
                     {
@@ -514,7 +514,7 @@
 
 jQuery(document).ready(function () {
     var form = jQuery('#oktavia_search_form');
-    if (form.size() > 0)
+    if (form.length > 0)
     {
         form.oktaviaSearch();
     }


### PR DESCRIPTION
Since version 1.5, Sphinx uses jQuery 3.x ([changelog](http://www.sphinx-doc.org/en/stable/changes.html)).

However, `oktavia-jquery-ui.js` uses deprecated jQuery function `.size()` ([doc](http://api.jquery.com/size/)).

Fix the problem by replacing `.size()` with `.length`.