### PR TITLE
Fix Build section in README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ Build
 
 .. code-block:: bash
 
-   $ npm build
+   $ npm run build
 
 Run test
 ~~~~~~~~


### PR DESCRIPTION
`npm build` doesn't run the script named `build` in package.json. This is because npm build is actually already an internal command, as described in the [docs](https://docs.npmjs.com/cli/build).

Fix the document by replacing `npm build` with `npm run build`.